### PR TITLE
fix: Game result bug

### DIFF
--- a/src/components/Game.tsx
+++ b/src/components/Game.tsx
@@ -1,6 +1,5 @@
 import { useCallback, useEffect } from 'react';
 import { GameAction, GameState } from '../types/GameAction';
-import { GameOption } from '../types/GameOption';
 type GameProps = {
   dispatchEvent: React.Dispatch<GameAction>;
   gameState: GameState;
@@ -9,17 +8,7 @@ type GameProps = {
 export default function Game({ dispatchEvent, gameState }: GameProps) {
   const { playerChoice, machineChoice, winner } = gameState;
 
-  const machinePlay = useCallback(() => {
-    const options: GameOption[] = ['rock', 'paper', 'scissors'];
-    const randomIndex = Math.floor(Math.random() * options.length);
-    const machineChoice = options[randomIndex];
-
-    dispatchEvent({ type: 'SET_MACHINE_CHOICE', option: machineChoice });
-  }, [dispatchEvent]);
-
   const getResult = useCallback(() => {
-    machinePlay();
-
     if (playerChoice === 'paper' && machineChoice === 'paper') {
       dispatchEvent({ type: 'SET_WINNER', winner: 'draw' });
     } else if (playerChoice === 'paper' && machineChoice === 'rock') {
@@ -47,7 +36,7 @@ export default function Game({ dispatchEvent, gameState }: GameProps) {
     } else {
       dispatchEvent({ type: 'SET_WINNER', winner: 'draw' });
     }
-  }, [dispatchEvent, playerChoice, machineChoice, machinePlay]);
+  }, [dispatchEvent, playerChoice, machineChoice]);
 
   useEffect(() => {
     getResult();

--- a/src/components/Play.tsx
+++ b/src/components/Play.tsx
@@ -14,11 +14,12 @@ type PlayProps = {
 };
 
 export function Play({ dispatchEvent }: PlayProps) {
-  const [playerChoice, setPlayerChoice] = useState<GameOption | null>(null);
+  const [selectedPlayerChoice, setSelectedPlayerChoice] =
+    useState<GameOption | null>(null);
   const [isLoading, setIsLoading] = useState(false);
 
   function handlePlayerChoice(option: GameOption) {
-    setPlayerChoice(option);
+    setSelectedPlayerChoice(option);
   }
 
   async function handleFormSubmit(e: FormEvent<HTMLFormElement>) {
@@ -28,8 +29,19 @@ export function Play({ dispatchEvent }: PlayProps) {
     await sleep(1000);
     setIsLoading(false);
 
-    if (playerChoice) {
-      dispatchEvent({ type: 'SET_PLAYER_CHOICE', option: playerChoice });
+    if (selectedPlayerChoice) {
+      dispatchEvent({
+        type: 'SET_PLAYER_CHOICE',
+        option: selectedPlayerChoice,
+      });
+
+      const options: GameOption[] = ['rock', 'paper', 'scissors'];
+      const randomIndex = Math.floor(Math.random() * options.length);
+      const selectedMachineChoice = options[randomIndex];
+      dispatchEvent({
+        type: 'SET_MACHINE_CHOICE',
+        option: selectedMachineChoice,
+      });
     }
   }
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,5 @@
-import React from 'react'
-import ReactDOM from 'react-dom/client'
-import App from './App.tsx'
-import './index.css'
+import ReactDOM from 'react-dom/client';
+import App from './App.tsx';
+import './index.css';
 
-ReactDOM.createRoot(document.getElementById('root')!).render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>,
-)
+ReactDOM.createRoot(document.getElementById('root')!).render(<App />);


### PR DESCRIPTION
Because of `StrictMode`, when the result was calculated it was being rendered more than once.
With this behavior, the score is updated twice in a single play.

I removed `StrictMode`, moved `machineChoice` to the `Play` component, to make the behavior of the machine select an option after the user and then calculate the result.