### PR TITLE
feat: Implement repeated rock choice rule

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-hot-toast": "^2.4.1",
     "react-router-dom": "^6.22.3"
   },
   "devDependencies": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,3 +1,4 @@
+import { Toaster } from 'react-hot-toast';
 import { GameProvider } from './contexts/GameContext';
 import { Router } from './router';
 
@@ -5,6 +6,7 @@ export function App() {
   return (
     <GameProvider>
       <Router />
+      <Toaster />
     </GameProvider>
   );
 }

--- a/src/components/Option.tsx
+++ b/src/components/Option.tsx
@@ -8,22 +8,23 @@ type OptionProps = {
   value: GameOption;
   onPlayerChoice?: (value: GameOption) => void;
   disabled?: boolean;
+  optionError?: boolean;
 } & ComponentProps<'div'>;
 
 export function Option({
   value,
   onPlayerChoice,
   disabled,
+  optionError,
   ...props
 }: OptionProps) {
   function handleClick() {
     onPlayerChoice?.(value);
   }
-
   return (
     <div className="relative" {...props}>
       <span
-        className={`absolute -top-2.5 left-0 -z-10 w-0 origin-center scale-0 transform rounded-full bg-slate-100 transition-all duration-100 has-[:checked]:h-24 has-[:checked]:w-24 has-[:checked]:scale-100`}
+        className={`absolute -top-2.5 left-0 -z-10 w-0 origin-center scale-0 transform rounded-full bg-slate-100 transition-all duration-100 has-[:checked]:h-24 has-[:checked]:w-24 has-[:checked]:scale-100 ${optionError && 'hidden'}`}
       >
         <input type="checkbox" id={value} className="hidden" />
       </span>

--- a/src/pages/Game.tsx
+++ b/src/pages/Game.tsx
@@ -5,7 +5,8 @@ import { Tooltip } from '../components/Tooltip';
 import { useGameContext } from '../hooks/useGameContext';
 
 export default function Game() {
-  const { dispatch, machineChoice, playerChoice, state } = useGameContext();
+  const { dispatch, state } = useGameContext();
+  const { machineChoice, playerChoice } = state;
   const resultAlreadyCalculated = useRef(false);
 
   const navigate = useNavigate();

--- a/src/pages/Play.tsx
+++ b/src/pages/Play.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import toast from 'react-hot-toast';
 import { useNavigate } from 'react-router-dom';
 import { Option } from '../components/Option';
 import { Spinner } from '../components/Spinner';
@@ -8,9 +9,10 @@ import { GameOption } from '../types/GameOption';
 import { sleep } from '../utils/sleep';
 
 export function Play() {
-  const { dispatch } = useGameContext();
+  const { dispatch, checkPlayerChoice, setPlayerChoice } = useGameContext();
   const navigate = useNavigate();
   const [isLoading, setIsLoading] = useState(false);
+  const [rockOptionError, setRockOptionError] = useState(false);
 
   async function handlePlayerChoice(playerOption: GameOption) {
     setIsLoading(true);
@@ -18,10 +20,14 @@ export function Play() {
     setIsLoading(false);
 
     if (playerOption) {
-      dispatch({
-        type: 'SET_PLAYER_CHOICE',
-        option: playerOption,
-      });
+      const playerChoice = checkPlayerChoice(playerOption);
+
+      if (!playerChoice.ok) {
+        setRockOptionError(true);
+        return toast.error(playerChoice.message ?? 'Invalid option');
+      }
+
+      setPlayerChoice(playerOption);
 
       const options: GameOption[] = ['rock', 'paper', 'scissors'];
       const randomIndex = Math.floor(Math.random() * options.length);
@@ -48,6 +54,7 @@ export function Play() {
           <Option
             value="rock"
             disabled={isLoading}
+            optionError={rockOptionError}
             onPlayerChoice={handlePlayerChoice}
           />
         </Tooltip>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1522,6 +1522,11 @@ globby@^11.1.0:
     merge2 "^1.4.1"
     slash "^3.0.0"
 
+goober@^2.1.10:
+  version "2.1.14"
+  resolved "https://registry.yarnpkg.com/goober/-/goober-2.1.14.tgz#4a5c94fc34dc086a8e6035360ae1800005135acd"
+  integrity sha512-4UpC0NdGyAFqLNPnhCT2iHpza2q+RAY3GV85a/mRPdzyPQMsj0KmMMuetdIkzWRbJ+Hgau1EZztq8ImmiMGhsg==
+
 graphemer@^1.4.0:
   version "1.4.0"
   resolved "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz"
@@ -2227,6 +2232,13 @@ react-dom@^18.2.0:
   dependencies:
     loose-envify "^1.1.0"
     scheduler "^0.23.0"
+
+react-hot-toast@^2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/react-hot-toast/-/react-hot-toast-2.4.1.tgz#df04295eda8a7b12c4f968e54a61c8d36f4c0994"
+  integrity sha512-j8z+cQbWIM5LY37pR6uZR6D4LfseplqnuAO4co4u8917hBUvXlEqyP1ZzqVLcqoyUesZZv/ImreoCeHVDpE5pQ==
+  dependencies:
+    goober "^2.1.10"
 
 react-router-dom@^6.22.3:
   version "6.22.3"


### PR DESCRIPTION
This PR adds the only application's rule: The player cannot select rock option twice in a row.

It was also added a `Toaster` from `react-hot-toast`.